### PR TITLE
Major cleanup of bootstrap code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+build/*
+
+*.3dsx
+*.smdh
+*.elf

--- a/bootstrap.h
+++ b/bootstrap.h
@@ -1,3 +1,9 @@
+#pragma once
+
+#include <stdbool.h>
+
+extern unsigned int *arm11_buffer;
+
 int do_gshax_copy(void *dst, void *src, unsigned int len, unsigned int check_val, int check_off);
-int doARM11Hax();
-unsigned int *arm11_buffer;
+bool doARM11Hax();
+

--- a/main.c
+++ b/main.c
@@ -31,12 +31,7 @@ void waitKey() {
 int main()
 {
 	// Initialize services
-	srvInit();			// mandatory
-	aptInit();			// mandatory
-	hidInit(NULL);	// input (buttons, screen)
-	gfxInitDefault();			// graphics
-	fsInit();
-	sdmcInit();
+	gfxInitDefault(); // graphics
 	hbInit();
 
 	qtmInit();
@@ -53,12 +48,7 @@ int main()
 
 	// Exit services
 	hbExit();
-	sdmcExit();
-	fsExit();
 	gfxExit();
-	hidExit();
-	aptExit();
-	srvExit();
 	
 	// Return to hbmenu
 	return 0;

--- a/main.c
+++ b/main.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <malloc.h>
 #include <dirent.h>
+
 #include "bootstrap.h"
 
 void waitKey() {
@@ -34,17 +35,12 @@ int main()
 	gfxInitDefault(); // graphics
 	hbInit();
 
-	qtmInit();
 	consoleInit(GFX_TOP, NULL);
 
-	doARM11Hax();
+    while (!doARM11Hax());
 
-	//consoleClear();
-	printf("%x\n", arm11_buffer[0]);
-
+    printf("Success!\n\n");
 	waitKey();
-
-	printf("Exiting...\n");
 
 	// Exit services
 	hbExit();

--- a/utils.h
+++ b/utils.h
@@ -1,0 +1,7 @@
+#pragma once
+
+void InvalidateEntireInstructionCache(void);
+void InvalidateEntireDataCache(void);
+
+int svcBackdoor(int (*func)(void));
+

--- a/utils.s
+++ b/utils.s
@@ -11,3 +11,9 @@ InvalidateEntireDataCache:
 	mov r0, #0
 	mcr p15, 0, r0, c7, c10, 0
 	bx lr
+
+.global svcBackdoor
+.type svcBackdoor, %function
+svcBackdoor:
+   svc 0x7B
+   bx lr


### PR DESCRIPTION
- Removed unnecessary / redundant / useless code that was floating around
- Extracted some repetitive code into separate units
  - dbg_log
  - build_nop_slide
- Made assembly volatile (wouldn't want the compiler changing that!)
- Compressed the `if` chains in `get_version_specific_addresses` into a `switch` block
- Changed `doARM11Hax` to return a bool for success or failure
- Loop in `main` until `doARM11Hax` succeeds (or kernelpanicks the 3DS, as it is wont to do once in a while)
